### PR TITLE
cmd/anubis: allow qwantbot scraping

### DIFF
--- a/cmd/anubis/botPolicies.json
+++ b/cmd/anubis/botPolicies.json
@@ -16,6 +16,11 @@
       "action": "ALLOW"
     },
     {
+      "name": "qwantbot",
+      "user_agent_regex": "\\+https\\:\\/\\/help\\.qwant\\.com/bot/",
+      "action": "ALLOW"
+    },
+    {
       "name": "us-artificial-intelligence-scraper",
       "user_agent_regex": "\\+https\\:\\/\\/github\\.com\\/US-Artificial-Intelligence\\/scraper",
       "action": "DENY"


### PR DESCRIPTION
Like Google and Bing, Qwant maintains its own search index.