### PR TITLE
Uppercase word in tourian.templ (request from #701)

### DIFF
--- a/cmd/_old/tourian/tourian.templ
+++ b/cmd/_old/tourian/tourian.templ
@@ -207,7 +207,7 @@ templ messagePage() {
 				</p>
 				<hr/>
 				<p>
-					For the love of god can we also just stop putting AI stuff where it doesn't belong? I make toast because I want to make toast, not argue with my toaster about existentialism.
+					For the love of God can we also just stop putting AI stuff where it doesn't belong? I make toast because I want to make toast, not argue with my toaster about existentialism.
 				</p>
 			</article>
 			<div class="mt-6 p-4 mb-4 bg-gray-200 text-gray-800 rounded-lg">


### PR DESCRIPTION
To add support to this, both dictionaries below mention uppercase "God"

> for the love of God
> [idiom](https://www.merriam-webster.com/dictionary/idiom)
> informal
> —used to give added force to an angry statement
> For the love of God, quiet down! I'm trying to get some sleep here!

<https://www.merriam-webster.com/dictionary/for%20the%20love%20of%20God>

> for the love of God
> 
> ...From [Middle English](https://en.wikipedia.org/wiki/Middle_English) [for the luf of God](https://en.wiktionary.org/w/index.php?title=for_the_luf_of_God&action=edit&redlink=1), [for þe love of god](https://en.wiktionary.org/w/index.php?title=for_%C3%BEe_love_of_god&action=edit&redlink=1), [for ðe luve of gode](https://en.wiktionary.org/w/index.php?title=for_%C3%B0e_luve_of_gode&action=edit&redlink=1) (literally “for the love of God”) ...

<https://en.wiktionary.org/wiki/for_the_love_of_God>

Related issue #701