### PR TITLE
feat(mi): add member name alias support to switch tracker

### DIFF
--- a/cmd/mi/models/dao.go
+++ b/cmd/mi/models/dao.go
@@ -74,6 +74,20 @@ func (d *DAO) Members(ctx context.Context) ([]Member, error) {
 	return result, nil
 }
 
+// MemberByName finds a member by canonical name or alias.
+func (d *DAO) MemberByName(ctx context.Context, name string) (*Member, error) {
+	var members []Member
+	if err := d.db.WithContext(ctx).Find(&members).Error; err != nil {
+		return nil, err
+	}
+	for _, m := range members {
+		if m.MatchesName(name) {
+			return &m, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
 func (d *DAO) WhoIsFront(ctx context.Context) (*Switch, error) {
 	var sw Switch
 	if err := d.db.Joins("Member").Order("created_at DESC").First(&sw).Error; err != nil {
@@ -84,6 +98,13 @@ func (d *DAO) WhoIsFront(ctx context.Context) (*Switch, error) {
 }
 
 func (d *DAO) SwitchFront(ctx context.Context, memberName string) (*Switch, *Switch, error) {
+	// Resolve the member name (including aliases) before starting
+	// the transaction so the read uses the main connection.
+	newMember, err := d.MemberByName(ctx, memberName)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var old Switch
 	tx := d.db.Begin()
 
@@ -92,7 +113,7 @@ func (d *DAO) SwitchFront(ctx context.Context, memberName string) (*Switch, *Swi
 		return nil, nil, err
 	}
 
-	if old.Member.Name == memberName {
+	if old.Member.ID == newMember.ID {
 		tx.WithContext(ctx).Rollback()
 		return nil, nil, ErrCantSwitchToYourself
 	}
@@ -100,12 +121,6 @@ func (d *DAO) SwitchFront(ctx context.Context, memberName string) (*Switch, *Swi
 	now := time.Now()
 	old.EndedAt = &now
 	if err := tx.WithContext(ctx).Save(&old).Error; err != nil {
-		tx.Rollback()
-		return nil, nil, err
-	}
-
-	var newMember Member
-	if err := tx.WithContext(ctx).Where("name = ?", memberName).First(&newMember).Error; err != nil {
 		tx.Rollback()
 		return nil, nil, err
 	}

--- a/cmd/mi/models/member.go
+++ b/cmd/mi/models/member.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -13,6 +14,21 @@ type Member struct {
 	Name      string     `gorm:"uniqueIndex"` // the name of the member
 	AvatarURL string     // public URL to the member's avatar
 	Birthday  *time.Time // optional birthday as RFC 3339 timestamp
+	Aliases   string     // comma-separated list of alternative names
+}
+
+// MatchesName reports whether the given name matches this member's
+// canonical name or any of their aliases (case-insensitive).
+func (m Member) MatchesName(name string) bool {
+	if strings.EqualFold(m.Name, name) {
+		return true
+	}
+	for _, alias := range strings.Split(m.Aliases, ",") {
+		if alias = strings.TrimSpace(alias); alias != "" && strings.EqualFold(alias, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // AsProto converts a Member to its protobuf representation.

--- a/cmd/mi/models/member_test.go
+++ b/cmd/mi/models/member_test.go
@@ -1,0 +1,77 @@
+package models
+
+import "testing"
+
+func TestMemberMatchesName(t *testing.T) {
+	tests := []struct {
+		name    string
+		member  Member
+		input   string
+		want    bool
+	}{
+		{
+			name:   "exact canonical name",
+			member: Member{Name: "Cadey", Aliases: "xe,cadey-ratio"},
+			input:  "Cadey",
+			want:   true,
+		},
+		{
+			name:   "canonical name case insensitive",
+			member: Member{Name: "Cadey", Aliases: "xe,cadey-ratio"},
+			input:  "cadey",
+			want:   true,
+		},
+		{
+			name:   "alias match",
+			member: Member{Name: "Cadey", Aliases: "xe,cadey-ratio"},
+			input:  "xe",
+			want:   true,
+		},
+		{
+			name:   "alias case insensitive",
+			member: Member{Name: "Cadey", Aliases: "xe,cadey-ratio"},
+			input:  "Xe",
+			want:   true,
+		},
+		{
+			name:   "alias with spaces in list",
+			member: Member{Name: "Cadey", Aliases: "xe, cadey-ratio"},
+			input:  "cadey-ratio",
+			want:   true,
+		},
+		{
+			name:   "no match",
+			member: Member{Name: "Cadey", Aliases: "xe,cadey-ratio"},
+			input:  "Nicole",
+			want:   false,
+		},
+		{
+			name:   "empty aliases",
+			member: Member{Name: "Cadey"},
+			input:  "Cadey",
+			want:   true,
+		},
+		{
+			name:   "empty aliases no match",
+			member: Member{Name: "Cadey"},
+			input:  "xe",
+			want:   false,
+		},
+		{
+			name:   "empty input",
+			member: Member{Name: "Cadey", Aliases: "xe"},
+			input:  "",
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.member.MatchesName(tc.input)
+			if got != tc.want {
+				t.Errorf("Member{Name: %q, Aliases: %q}.MatchesName(%q) = %v, want %v",
+					tc.member.Name, tc.member.Aliases, tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/mi/services/switchtracker/switchtracker.go
+++ b/cmd/mi/services/switchtracker/switchtracker.go
@@ -57,9 +57,8 @@ func (s *Server) WhoIsFront(ctx context.Context, _ *emptypb.Empty) (*pb.FrontCha
 }
 
 func (s *Server) Switch(ctx context.Context, req *pb.SwitchReq) (*pb.SwitchResp, error) {
-	if err := protovalidate.Validate(req); err != nil {
-		slog.Error("can't switch without a member", "req", req, "err", err)
-		return nil, twirp.InvalidArgumentError("member_name", err.Error())
+	if req.GetMemberName() == "" {
+		return nil, twirp.RequiredArgumentError("member_name")
 	}
 
 	old, new, err := s.dao.SwitchFront(ctx, req.GetMemberName())

--- a/pb/within/website/x/mi/v1/mi.proto
+++ b/pb/within/website/x/mi/v1/mi.proto
@@ -33,15 +33,8 @@ message Switch {
 
 message SwitchReq {
   string member_name = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).cel = {
-      id: "member_name.is_in_system"
-      message: "member_name must be in Within"
-      expression:
-        "this in [\"Cadey\", \"Nicole\", \"Jessie\", \"Sephie\", "
-        "\"Ashe\", \"Mai\", \"W'zamqo\"]"
-    }
-  ]; // required
+    (buf.validate.field).required = true
+  ]; // required, resolved against member names and aliases
 }
 
 message SwitchResp {

--- a/pb/within/website/x/mi/v1/mi.proto
+++ b/pb/within/website/x/mi/v1/mi.proto
@@ -32,9 +32,7 @@ message Switch {
 }
 
 message SwitchReq {
-  string member_name = 1 [
-    (buf.validate.field).required = true
-  ]; // required, resolved against member names and aliases
+  string member_name = 1 [(buf.validate.field).required = true]; // required, resolved against member names and aliases
 }
 
 message SwitchResp {


### PR DESCRIPTION
Add an Aliases field to the Member struct and a MatchesName method that resolves names against both the canonical name and comma-separated aliases (case-insensitive). Integrate alias resolution into SwitchFront via a new MemberByName DAO method, and relax the proto CEL validation so alias names can pass through the API.

Assisted-by: Claude Opus 4.6 via Claude Code
Reviewbot-request: yes

https://claude.ai/code/session_01TcLYSD9YMqk9Rn6ZUbejoo

## Summary

<!-- Bullet points describing the high-level changes -->

-
-

## Details

<!-- Detailed explanation of what changed and why -->

## Test plan

<!-- Checklist of testing items -->

- [ ] Code compiles with `go build ./...`
- [ ] Code formatted with `npm run format`
- [ ] Manual testing
